### PR TITLE
Fix request encode error when data contains non-ASCII characters

### DIFF
--- a/netvisor/requests/base.py
+++ b/netvisor/requests/base.py
@@ -22,6 +22,7 @@ class Request(object):
             method=self.method,
             path=self.uri,
             params=self.params,
+            headers={'content-type': 'text/xml; charset=utf-8'},
             data=self.unparse()
         )
         return self.parse_response(response)
@@ -47,7 +48,7 @@ class Request(object):
                 pretty=True,
                 indent='  '
             )
-            return self._remove_xml_declaration(xml)
+            return self._remove_xml_declaration(xml).encode('utf-8')
 
     def _remove_xml_declaration(self, xml):
         return xml.replace('<?xml version="1.0" encoding="utf-8"?>\n', '', 1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ def get_requests_dir():
 
 def read_file(filename):
     with io.open(filename, 'r', encoding='utf-8') as f:
-        return f.read()
+        return f.read().encode('utf-8')
 
 
 def get_response_content(filename):


### PR DESCRIPTION
The fix encodes payload explicitly to utf-8. Previously, requests package encoded payload to bytes implicitly which failed if payload contained non-ASCII characters.
