### PR TITLE
Add free text field for sales invoice product line

### DIFF
--- a/netvisor/schemas/sales_invoices/create.py
+++ b/netvisor/schemas/sales_invoices/create.py
@@ -48,6 +48,7 @@ class SalesInvoiceProductLineSchema(RejectUnknownFieldsSchema):
     sales_invoice_product_line_discount_percentage = Decimal(
         attribute='discount_percentage'
     )
+    sales_invoice_product_line_free_text = fields.String(attribute='free_text')
     accounting_account_suggestion = fields.String()
 
     class Meta:

--- a/tests/data/requests/SalesInvoice.xml
+++ b/tests/data/requests/SalesInvoice.xml
@@ -32,6 +32,7 @@
           <ProductVatPercentage vatcode="KOMY">22</ProductVatPercentage>
           <SalesInvoiceProductLineQuantity>2</SalesInvoiceProductLineQuantity>
           <SalesInvoiceProductLineDiscountPercentage>0</SalesInvoiceProductLineDiscountPercentage>
+          <SalesInvoiceProductLineFreeText>Punainen</SalesInvoiceProductLineFreeText>
           <AccountingAccountSuggestion>3000</AccountingAccountSuggestion>
         </SalesInvoiceProductLine>
       </InvoiceLine>
@@ -42,6 +43,7 @@
           <ProductUnitPrice type="net">100,00</ProductUnitPrice>
           <ProductVatPercentage vatcode="KOMY">22</ProductVatPercentage>
           <SalesInvoiceProductLineQuantity>1</SalesInvoiceProductLineQuantity>
+          <SalesInvoiceProductLineFreeText>Keltainen</SalesInvoiceProductLineFreeText>
           <AccountingAccountSuggestion>3200</AccountingAccountSuggestion>
         </SalesInvoiceProductLine>
       </InvoiceLine>

--- a/tests/services/test_sales_invoice.py
+++ b/tests/services/test_sales_invoice.py
@@ -284,6 +284,7 @@ class TestSalesInvoiceService(object):
                     },
                     'quantity': decimal.Decimal('2'),
                     'discount_percentage': decimal.Decimal('0'),
+                    'free_text': 'Punainen',
                     'accounting_account_suggestion': '3000'
                 },
                 {
@@ -298,6 +299,7 @@ class TestSalesInvoiceService(object):
                         'code': 'KOMY',
                     },
                     'quantity': decimal.Decimal('1'),
+                    'free_text': 'Keltainen',
                     'accounting_account_suggestion': '3200'
                 }
             ]
@@ -398,6 +400,7 @@ class TestSalesInvoiceService(object):
                     },
                     'quantity': decimal.Decimal('2'),
                     'discount_percentage': decimal.Decimal('0'),
+                    'free_text': 'Punainen',
                     'accounting_account_suggestion': '3000'
                 },
                 {
@@ -412,6 +415,7 @@ class TestSalesInvoiceService(object):
                         'code': 'KOMY',
                     },
                     'quantity': decimal.Decimal('1'),
+                    'free_text': 'Keltainen',
                     'accounting_account_suggestion': '3200'
                 }
             ]


### PR DESCRIPTION
I need to add free text for sales invoice product lines. I have manually tested the change with Netvisor API. [Related API specification](https://netvisor.zendesk.com/hc/fi/articles/201993993-Resources-Sales-invoices#ankkuri3)
