### PR TITLE
Fix EmailInvoicingAddress position in request

### DIFF
--- a/netvisor/schemas/customers/create.py
+++ b/netvisor/schemas/customers/create.py
@@ -26,9 +26,9 @@ class CustomerBaseInformationSchema(RejectUnknownFieldsSchema):
     phone_number = fields.String()
     fax_number = fields.String()
     email = fields.String()
-    email_invoicing_address = fields.String()
     home_page_uri = fields.String()
     is_active = Boolean(true='1', false='0')
+    email_invoicing_address = fields.String()
 
     class Meta:
         ordered = True

--- a/tests/data/requests/Customer.xml
+++ b/tests/data/requests/Customer.xml
@@ -14,9 +14,9 @@
       <PhoneNumber>040 123456</PhoneNumber>
       <FaxNumber>05 123456</FaxNumber>
       <Email>matti.meikalainen@firma.fi</Email>
-      <EmailInvoicingAddress>maija.meikalainen@firma.fi</EmailInvoicingAddress>
       <HomePageUri>www.firma.fi</HomePageUri>
       <IsActive>1</IsActive>
+      <EmailInvoicingAddress>maija.meikalainen@firma.fi</EmailInvoicingAddress>
     </CustomerBaseInformation>
     <CustomerFinvoiceDetails>
       <FinvoiceAddress>FI109700021497</FinvoiceAddress>


### PR DESCRIPTION
Netvisor requires that request fields come in certain order.
I failed to use correct ordering in #4.

The issue does not affect responses as netvisor.py
is more lenient with field order.

Correct ordering can bee seen from [the documentation](https://netvisor.zendesk.com/hc/fi/articles/201993973-Resources-Customer-register-and-company-information#ankkuri4).
