### PR TITLE
Add accounting list

### DIFF
--- a/netvisor/core.py
+++ b/netvisor/core.py
@@ -8,6 +8,7 @@
 """
 from .auth import NetvisorAuth
 from .client import Client
+from .services.accounting import AccountingService
 from .services.company import CompanyService
 from .services.customer import CustomerService
 from .services.product import ProductService
@@ -30,3 +31,4 @@ class Netvisor(object):
         self.products = ProductService(self._client)
         self.sales_invoices = SalesInvoiceService(self._client)
         self.sales_payments = SalesPaymentService(self._client)
+        self.accounting = AccountingService(self._client)

--- a/netvisor/requests/accounting.py
+++ b/netvisor/requests/accounting.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+    netvisor.requests.accounting
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: (c) 2013-2016 by Fast Monkeys Oy.
+    :license: MIT, see LICENSE for more details.
+"""
+from ..responses.accounting import AccountingListResponse
+from .base import Request
+
+
+class AccountingListRequest(Request):
+    method = 'GET'
+    uri = 'AccountingLedger.nv'
+    response_cls = AccountingListResponse

--- a/netvisor/responses/accounting.py
+++ b/netvisor/responses/accounting.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""
+    netvisor.responses.accounting
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: (c) 2013-2016 by Fast Monkeys Oy.
+    :license: MIT, see LICENSE for more details.
+"""
+from ..schemas import AccountingListSchema
+from .base import Response
+
+
+class AccountingListResponse(Response):
+    schema_cls = AccountingListSchema
+    tag_name = 'vouchers'

--- a/netvisor/schemas/__init__.py
+++ b/netvisor/schemas/__init__.py
@@ -1,3 +1,4 @@
+from .accounting import AccountingListSchema  # noqa
 from .companies import CompanyListSchema, GetCompanyInformationSchema  # noqa
 from .customers import (  # noqa
     CreateCustomerSchema,

--- a/netvisor/schemas/accounting/__init__.py
+++ b/netvisor/schemas/accounting/__init__.py
@@ -1,0 +1,1 @@
+from .list import AccountingListSchema  # noqa

--- a/netvisor/schemas/accounting/list.py
+++ b/netvisor/schemas/accounting/list.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+    netvisor.schemas.accounting.list
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: (c) 2013-2016 by Fast Monkeys Oy.
+    :license: MIT, see LICENSE for more details.
+"""
+from marshmallow import Schema, fields, post_load
+
+from ..fields import Decimal, FinnishDate, List
+
+
+class DimensionSchema(Schema):
+    name = fields.String(load_from='dimension_name')
+    item = fields.String(load_from='dimension_item')
+
+
+class VoucherLineSchema(Schema):
+    line_sum = Decimal()
+    description = fields.String(allow_none=True)
+    account_number = fields.Integer()
+    vat_percent = fields.Integer()
+    dimensions = List(
+        fields.Nested(DimensionSchema),
+        load_from='dimension',
+        missing=list
+    )
+
+
+class VoucherNetvisorURISchema(Schema):
+    type = fields.String(load_from='@type')
+    key = fields.Integer(load_from='#text')
+
+
+class VoucherSchema(Schema):
+    status = fields.String(load_from='@status')
+    key = fields.Integer(load_from='netvisor_key')
+    date = FinnishDate(load_from='voucher_date')
+    number = fields.Integer(load_from='voucher_number')
+    description = fields.String(
+        load_from='voucher_description',
+        allow_none=True
+    )
+    class_ = fields.String(attribute='class', load_from='voucher_class')
+    linked_source = fields.Nested(
+        VoucherNetvisorURISchema,
+        load_from='linked_source_netvisor_key'
+    )
+    uri = fields.String(load_from='voucher_netvisor_uri')
+    lines = List(
+        fields.Nested(VoucherLineSchema),
+        load_from='voucher_line',
+        missing=list
+    )
+
+
+class AccountingListSchema(Schema):
+    vouchers = List(
+        fields.Nested(VoucherSchema),
+        load_from='voucher'
+    )
+
+    @post_load
+    def preprocess_voucher_list(self, input_data):
+        return input_data['vouchers'] if input_data else []

--- a/netvisor/services/accounting.py
+++ b/netvisor/services/accounting.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+    netvisor.services.accounting
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: (c) 2013-2016 by Fast Monkeys Oy.
+    :license: MIT, see LICENSE for more details.
+"""
+from ..requests.accounting import AccountingListRequest
+from .base import Service
+
+
+class AccountingService(Service):
+    def list(
+        self, start_date=None, end_date=None,
+        account_number_start=None, account_number_end=None,
+        last_modified_start=None, last_modified_end=None,
+        netvisor_key_list=None, voucherstatus=None, changed_since=None,
+    ):
+        query = {}
+        if start_date is not None:
+            query['StartDate'] = start_date.isoformat()
+        if end_date is not None:
+            query['EndDate'] = end_date.isoformat()
+        if account_number_start is not None:
+            query['AccountNumberStart'] = account_number_start
+        if account_number_end is not None:
+            query['AccountNumberEnd'] = account_number_end
+        if last_modified_start is not None:
+            query['LastModifiedStart'] = last_modified_start.isoformat()
+        if last_modified_end is not None:
+            query['LastModifiedEnd'] = last_modified_end.isoformat()
+        if netvisor_key_list is not None:
+            query['NetvisorKeyList'] = (
+                ','.join(str(key) for key in netvisor_key_list)
+            )
+        if voucherstatus is not None:
+            query['Voucherstatus'] = voucherstatus
+        if changed_since is not None:
+            query['ChangedSince'] = changed_since.isoformat()
+        request = AccountingListRequest(self.client, params=query)
+        return request.make_request()

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     platforms='any',
     install_requires=[
         'inflection',
-        'marshmallow>=2.0.0',
+        'marshmallow>=2.0.0,!=2.10.0',
         'requests',
         'xmltodict>=0.10.1',
     ],

--- a/tests/data/responses/AccountingList.xml
+++ b/tests/data/responses/AccountingList.xml
@@ -1,0 +1,61 @@
+<Root>
+  <ResponseStatus>
+    <Status>OK</Status>
+    <TimeStamp>1.10.2009 16:03:24</TimeStamp>
+  </ResponseStatus>
+  <Vouchers>
+    <Voucher Status="valid">
+      <NetvisorKey>12</NetvisorKey>
+      <VoucherDate>1.1.2000</VoucherDate>
+      <VoucherNumber>13</VoucherNumber>
+      <VoucherDescription>Invoice 14</VoucherDescription>
+      <VoucherClass>PI Purchase Invoice</VoucherClass>
+      <LinkedSourceNetvisorKey type="purchaseinvoice">15</LinkedSourceNetvisorKey>
+      <VoucherNetvisorURI>https:/netvisor.com/voucher/16</VoucherNetvisorURI>
+      <VoucherLine>
+        <LineSum>-17,18</LineSum>
+        <Description>Invoice 19</Description>
+        <AccountNumber>100</AccountNumber>
+        <VatPercent>20</VatPercent>
+      </VoucherLine>
+      <VoucherLine>
+        <LineSum>-21,22</LineSum>
+        <Description>Invoice 23</Description>
+        <AccountNumber>200</AccountNumber>
+        <VatPercent>24</VatPercent>
+      </VoucherLine>
+    </Voucher>
+    <Voucher Status="invalidated">
+      <NetvisorKey>25</NetvisorKey>
+      <VoucherDate>2.1.2000</VoucherDate>
+      <VoucherNumber>26</VoucherNumber>
+      <VoucherDescription>Invoice 27</VoucherDescription>
+      <VoucherClass>SA Sales Invoice</VoucherClass>
+      <LinkedSourceNetvisorKey type="salesinvoice">28</LinkedSourceNetvisorKey>
+      <VoucherNetvisorURI>https:/netvisor.com/voucher/29</VoucherNetvisorURI>
+      <VoucherLine>
+        <LineSum>-30,31</LineSum>
+        <Description>Invoice 32</Description>
+        <AccountNumber>300</AccountNumber>
+        <VatPercent>33</VatPercent>
+        <Dimension>
+            <DimensionName>Sales</DimensionName>
+            <DimensionItem>Mike</DimensionItem>
+        </Dimension>
+        <Dimension>
+            <DimensionName>Purchase</DimensionName>
+            <DimensionItem>Matt</DimensionItem>
+        </Dimension>
+      </VoucherLine>
+    </Voucher>
+    <Voucher>
+      <NetvisorKey>36</NetvisorKey>
+      <VoucherDate>3.1.2000</VoucherDate>
+      <VoucherNumber>37</VoucherNumber>
+      <VoucherDescription>Invoice 38</VoucherDescription>
+      <VoucherClass>Placeholder</VoucherClass>
+      <LinkedSourceNetvisorKey type="salesinvoice">38</LinkedSourceNetvisorKey>
+      <VoucherNetvisorURI>https:/netvisor.com/voucher/39</VoucherNetvisorURI>
+    </Voucher>
+  </Vouchers>
+</Root>

--- a/tests/services/test_accounting.py
+++ b/tests/services/test_accounting.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from ..utils import get_response_content
+
+
+class TestAccountingService(object):
+    def test_list(self, netvisor, responses):
+        responses.add(
+            method='GET',
+            url='http://koulutus.netvisor.fi/AccountingLedger.nv',
+            body=get_response_content('AccountingList.xml'),
+            content_type='text/html; charset=utf-8',
+            match_querystring=True
+        )
+        accounting = netvisor.accounting.list()
+        assert accounting == [
+            {
+                'status': 'valid',
+                'key': 12,
+                'date': date(2000, 1, 1),
+                'number': 13,
+                'description': 'Invoice 14',
+                'class': 'PI Purchase Invoice',
+                'linked_source': {'type': 'purchaseinvoice', 'key': 15},
+                'uri': 'https:/netvisor.com/voucher/16',
+                'lines': [
+                    {
+                        'line_sum': Decimal('-17.18'),
+                        'description': 'Invoice 19',
+                        'account_number': 100,
+                        'vat_percent': 20,
+                        'dimensions': []
+                    },
+                    {
+                        'line_sum': Decimal('-21.22'),
+                        'description': 'Invoice 23',
+                        'account_number': 200,
+                        'vat_percent': 24,
+                        'dimensions': []
+                    }
+                ]
+            },
+            {
+                'status': 'invalidated',
+                'key': 25,
+                'date': date(2000, 1, 2),
+                'number': 26,
+                'description': 'Invoice 27',
+                'class': 'SA Sales Invoice',
+                'linked_source': {'type': 'salesinvoice', 'key': 28},
+                'uri': 'https:/netvisor.com/voucher/29',
+                'lines': [
+                    {
+                        'line_sum': Decimal('-30.31'),
+                        'description': 'Invoice 32',
+                        'account_number': 300,
+                        'vat_percent': 33,
+                        'dimensions': [
+                            {
+                                'name': 'Sales',
+                                'item': 'Mike'
+                            },
+                            {
+                                'name': 'Purchase',
+                                'item': 'Matt'
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                'key': 36,
+                'date': date(2000, 1, 3),
+                'number': 37,
+                'description': 'Invoice 38',
+                'class': 'Placeholder',
+                'linked_source': {'type': 'salesinvoice', 'key': 38},
+                'uri': 'https:/netvisor.com/voucher/39',
+                'lines': []
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        ('parameter', 'key'),
+        [
+            ('start_date', 'StartDate'),
+            ('end_date', 'EndDate'),
+            ('last_modified_start', 'LastModifiedStart'),
+            ('last_modified_end', 'LastModifiedEnd'),
+            ('changed_since', 'ChangedSince'),
+        ]
+    )
+    def test_date_parameters(self, netvisor, responses, parameter, key):
+        value = date(2000, 1, 2)
+        url = (
+            'http://koulutus.netvisor.fi/AccountingLedger.nv?%s=2000-01-02' %
+            key
+        )
+        responses.add(
+            method='GET',
+            url=url,
+            body=get_response_content('AccountingList.xml'),
+            content_type='text/html; charset=utf-8',
+            match_querystring=True
+        )
+        assert netvisor.accounting.list(**{parameter: value}) is not None
+        request = responses.calls[0].request
+        assert request.url == url
+
+    @pytest.mark.parametrize(
+        ('parameter', 'key'),
+        [
+            ('account_number_start', 'AccountNumberStart'),
+            ('account_number_end', 'AccountNumberEnd'),
+            ('voucherstatus', 'Voucherstatus'),
+        ]
+    )
+    def test_integer_parameters(self, netvisor, responses, parameter, key):
+        value = 1
+        url = (
+            'http://koulutus.netvisor.fi/AccountingLedger.nv?%s=1' %
+            key
+        )
+        responses.add(
+            method='GET',
+            url=url,
+            body=get_response_content('AccountingList.xml'),
+            content_type='text/html; charset=utf-8',
+            match_querystring=True
+        )
+        assert netvisor.accounting.list(**{parameter: value}) is not None
+        request = responses.calls[0].request
+        assert request.url == url
+
+    def test_netvisor_key_list_parameter(self, netvisor, responses):
+        url = (
+            'http://koulutus.netvisor.fi/AccountingLedger.nv?'
+            'NetvisorKeyList=1%2C2%2C3'
+        )
+        responses.add(
+            method='GET',
+            url=url,
+            body=get_response_content('AccountingList.xml'),
+            content_type='text/html; charset=utf-8',
+            match_querystring=True
+        )
+        assert (
+            netvisor.accounting.list(netvisor_key_list=[1, 2, 3]) is not None
+        )
+        request = responses.calls[0].request
+        assert request.url == url


### PR DESCRIPTION
Refs fastmonkeys/netvisor.py#6

I made a couple of choices: Let's say that `accounting = netvisor.accounting.list()`.
- `accounting` is always a list.
- `accounting[i]['lines']` is always a list. (Provided that index "i" exist.)
- `accounting[i]['lines'][j]['dimensions']` is always a list. (Provided that indexes "i" and "j" exist.)
- I shortened many names like `voucher_date` -> `date`, `netvisor_key` -> `key`.
- Fields like `date = FinnishDate(load_from='voucher_date')` could have been written as `voucher_date = FinnishDate(attribute='date')`
